### PR TITLE
Feature/interpolated columns

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/test/samples/** text eol=lf

--- a/src/source-map-tree.ts
+++ b/src/source-map-tree.ts
@@ -120,7 +120,7 @@ export default class SourceMapTree {
 
     let index = binarySearch(segments, column, segmentComparator);
 
-    // If we can't find an segment that lines up to this column, we use the 
+    // If we can't find an segment that lines up to this column, we use the
     // closest segment before it, and offset the source column
     if (index < 0) {
       index = ~index - 1;
@@ -129,13 +129,13 @@ export default class SourceMapTree {
 
     const segment = segments[index];
     if (!segment) return null;
-    
+
     // 1-length segments only move the current generated column, there's no
     // source information to gather from it.
     if (segment.length === 1) return null;
     const source = this.sources[segment[1]];
 
-    // calculate the new column based on the difference between the column we 
+    // calculate the new column based on the difference between the column we
     // were searching for, and the start of the segment we found
     const offset = column - segment[0];
     const originalCol = segment[3] + offset;

--- a/src/source-map-tree.ts
+++ b/src/source-map-tree.ts
@@ -135,8 +135,7 @@ export default class SourceMapTree {
     if (segment.length === 1) return null;
     const source = this.sources[segment[1]];
 
-     
-    const originalCol = segment[3]
+    const originalCol = segment[3];
     const originalLine = segment[2];
     // So now we can recurse down, until we hit the original source file.
     return source.traceSegment(

--- a/src/source-map-tree.ts
+++ b/src/source-map-tree.ts
@@ -120,27 +120,25 @@ export default class SourceMapTree {
 
     let index = binarySearch(segments, column, segmentComparator);
 
-    // If we can't find an segment that lines up to this column, we use the
-    // closest segment before it.
+    if (index === -1) return null; // we come before any mapped segment
+
+    // If we can't find a segment that lines up to this column, we use the
+    // segment before.
     if (index < 0) {
       index = ~index - 1;
-      if (index < 0) return null; // we come before any mapped segment
     }
 
     const segment = segments[index];
-    if (!segment) return null;
 
     // 1-length segments only move the current generated column, there's no
     // source information to gather from it.
     if (segment.length === 1) return null;
     const source = this.sources[segment[1]];
 
-    const originalCol = segment[3];
-    const originalLine = segment[2];
     // So now we can recurse down, until we hit the original source file.
     return source.traceSegment(
-      originalLine,
-      originalCol,
+      segment[2],
+      segment[3],
       // A child map's recorded name for this segment takes precedence over the
       // parent's mapped name. Imagine a mangler changing the name over, etc.
       segment.length === 5 ? names[segment[4]] : name

--- a/src/source-map-tree.ts
+++ b/src/source-map-tree.ts
@@ -121,7 +121,7 @@ export default class SourceMapTree {
     let index = binarySearch(segments, column, segmentComparator);
 
     // If we can't find an segment that lines up to this column, we use the
-    // closest segment before it, and offset the source column
+    // closest segment before it.
     if (index < 0) {
       index = ~index - 1;
       if (index < 0) return null; // we come before any mapped segment
@@ -135,10 +135,8 @@ export default class SourceMapTree {
     if (segment.length === 1) return null;
     const source = this.sources[segment[1]];
 
-    // calculate the new column based on the difference between the column we
-    // were searching for, and the start of the segment we found
-    const offset = column - segment[0];
-    const originalCol = segment[3] + offset;
+     
+    const originalCol = segment[3]
     const originalLine = segment[2];
     // So now we can recurse down, until we hit the original source file.
     return source.traceSegment(

--- a/src/source-map-tree.ts
+++ b/src/source-map-tree.ts
@@ -116,7 +116,7 @@ export default class SourceMapTree {
 
     const segments = mappings[line];
 
-    if (segments.length == 0) return null;
+    if (segments.length === 0) return null;
 
     let index = binarySearch(segments, column, segmentComparator);
 
@@ -124,7 +124,7 @@ export default class SourceMapTree {
     // closest segment before it, and offset the source column
     if (index < 0) {
       index = ~index - 1;
-      if (index < 0) return null; //we come before any mapped segment
+      if (index < 0) return null; // we come before any mapped segment
     }
 
     const segment = segments[index];

--- a/test/samples/transpile-concat-hires/test.ts
+++ b/test/samples/transpile-concat-hires/test.ts
@@ -30,38 +30,44 @@ describe('transpile then concatenate', () => {
     });
 
     const consumer = new SourceMapConsumer((remapped as unknown) as RawSourceMap);
-    // middle o in foo in bundle.js
-    const foo = consumer.originalPositionFor({
-      column: 11,
-      line: 17,
-    });
-    expect(foo).toMatchObject({
-      column: 18,
-      line: 17,
-      source: 'main.mjs',
-    });
+    // the foo in bundle.js
+    for (let j = 10; j <= 12; j++) {
+      const foo = consumer.originalPositionFor({
+        column: j,
+        line: 17,
+      });
+      expect(foo).toMatchObject({
+        column: 18,
+        line: 17,
+        source: 'main.mjs',
+      });
+    }
 
-    // the a in bar in bundle.js
-    const bar = consumer.originalPositionFor({
-      column: 11,
-      line: 36,
-    });
-    expect(bar).toMatchObject({
-      column: 18,
-      line: 17,
-      source: 'placeholder.mjs',
-    });
+    // the bar in bundle.js
+    for (let j = 10; j <= 12; j++) {
+      const bar = consumer.originalPositionFor({
+        column: j,
+        line: 36,
+      });
+      expect(bar).toMatchObject({
+        column: 18,
+        line: 17,
+        source: 'placeholder.mjs',
+      });
+    }
 
-    //the a in baz in bundle.js
-    const baz = consumer.originalPositionFor({
-      column: 11,
-      line: 43,
-    });
-    expect(baz).toMatchObject({
-      column: 18,
-      line: 21,
-      source: 'main.mjs',
-    });
+    //the baz in bundle.js
+    for (let j = 10; j <= 12; j++) {
+      const baz = consumer.originalPositionFor({
+        column: j,
+        line: 43,
+      });
+      expect(baz).toMatchObject({
+        column: 18,
+        line: 21,
+        source: 'main.mjs',
+      });
+    }
   });
 
   test('inherits sourcesContent of original sources', () => {

--- a/test/samples/transpile-concat-hires/test.ts
+++ b/test/samples/transpile-concat-hires/test.ts
@@ -36,7 +36,7 @@ describe('transpile then concatenate', () => {
       line: 17,
     });
     expect(foo).toMatchObject({
-      column: 20,
+      column: 18,
       line: 17,
       source: 'main.mjs',
     });
@@ -47,7 +47,7 @@ describe('transpile then concatenate', () => {
       line: 36,
     });
     expect(bar).toMatchObject({
-      column: 20,
+      column: 18,
       line: 17,
       source: 'placeholder.mjs',
     });
@@ -58,7 +58,7 @@ describe('transpile then concatenate', () => {
       line: 43,
     });
     expect(baz).toMatchObject({
-      column: 20,
+      column: 18,
       line: 21,
       source: 'main.mjs',
     });

--- a/test/samples/transpile-concat-hires/test.ts
+++ b/test/samples/transpile-concat-hires/test.ts
@@ -40,7 +40,7 @@ describe('transpile then concatenate', () => {
       line: 17,
       source: 'main.mjs',
     });
-    
+
     // the a in bar in bundle.js
     const bar = consumer.originalPositionFor({
       column: 11,

--- a/test/samples/transpile-concat-hires/test.ts
+++ b/test/samples/transpile-concat-hires/test.ts
@@ -30,33 +30,35 @@ describe('transpile then concatenate', () => {
     });
 
     const consumer = new SourceMapConsumer((remapped as unknown) as RawSourceMap);
-
+    // middle o in foo in bundle.js
     const foo = consumer.originalPositionFor({
       column: 11,
       line: 17,
     });
     expect(foo).toMatchObject({
-      column: 18,
+      column: 20,
       line: 17,
       source: 'main.mjs',
     });
-
+    
+    // the a in bar in bundle.js
     const bar = consumer.originalPositionFor({
       column: 11,
       line: 36,
     });
     expect(bar).toMatchObject({
-      column: 18,
+      column: 20,
       line: 17,
       source: 'placeholder.mjs',
     });
 
+    //the a in baz in bundle.js
     const baz = consumer.originalPositionFor({
       column: 11,
       line: 43,
     });
     expect(baz).toMatchObject({
-      column: 18,
+      column: 20,
       line: 21,
       source: 'main.mjs',
     });

--- a/test/samples/transpile-minify/test.ts
+++ b/test/samples/transpile-minify/test.ts
@@ -31,7 +31,7 @@ describe('transpile then minify', () => {
 
     const consumer = new SourceMapConsumer((remapped as unknown) as RawSourceMap);
     const alert = consumer.originalPositionFor({
-      column: 61,
+      column: 47,
       line: 16,
     });
     expect(alert).toEqual({

--- a/test/unit/source-map-tree.ts
+++ b/test/unit/source-map-tree.ts
@@ -172,7 +172,11 @@ describe('SourceMapTree', () => {
           [0, 0, 4, 0],
           [5, 0, 4, 6],
         ], // line 4 is identical to line 4 of source except col 5 was removed eg 01234567890 -> 012346789
-        [[0, 0, 5, 0], [5], [6, 0, 5, 5]], // line 4 is identical to line 4 of source except a char was added at col 5 eg 01234*56789 -> 0123*456789
+        [
+          [0, 0, 5, 0],
+          [5],
+          [6, 0, 5, 5]
+        ], // line 4 is identical to line 4 of source except a char was added at col 5 eg 01234*56789 -> 0123*456789
       ],
       names: ['name'],
       sources: ['child.js'],

--- a/test/unit/source-map-tree.ts
+++ b/test/unit/source-map-tree.ts
@@ -199,9 +199,9 @@ describe('SourceMapTree', () => {
     });
 
     test('traces all generated cols on a line back to their source when source had characters added', () => {
-      let expectedCols = [0, 0, 0, 0, 0, null, 5, 5, 5, 5, 5];
-      let expectedLine = 5;
-      for (var genCol = 0; genCol < expectedCols.length; genCol++) {
+      const expectedCols = [0, 0, 0, 0, 0, null, 5, 5, 5, 5, 5];
+      const expectedLine = 5;
+      for (let genCol = 0; genCol < expectedCols.length; genCol++) {
         const trace = source.traceSegment(5, genCol, '');
         if (expectedCols[genCol] == null) {
           expect(trace).toBeNull();

--- a/test/unit/source-map-tree.ts
+++ b/test/unit/source-map-tree.ts
@@ -190,9 +190,9 @@ describe('SourceMapTree', () => {
     });
 
     test('traces all generated cols on a line back to their source when source had characters removed', () => {
-      let expectedCols = [0, 0, 0, 0, 0, 6, 6, 6, 6];
-      let expectedLine = 4;
-      for (var genCol = 0; genCol < expectedCols.length; genCol++) {
+      const expectedCols = [0, 0, 0, 0, 0, 6, 6, 6, 6];
+      const expectedLine = 4;
+      for (let genCol = 0; genCol < expectedCols.length; genCol++) {
         const trace = source.traceSegment(4, genCol, '');
         expect(trace).toMatchObject({ line: expectedLine, column: expectedCols[genCol] });
       }

--- a/test/unit/source-map-tree.ts
+++ b/test/unit/source-map-tree.ts
@@ -165,9 +165,11 @@ describe('SourceMapTree', () => {
           [2, 0, 0, 0],
           [4, 0, 1, 1],
         ], // line 0
-        [[1, 0, 0, 0]], // line 1
-        [[0]], // line 2
-        [[0, 0, 0, 0, 0]], // line 3
+        [[1, 0, 0, 0]], // line 1 - maps to line 0 col 0
+        [[0]], // line 2 has 1 length segment
+        [[0, 0, 0, 0, 0]], // line 3 has a name
+        [[0, 0, 4, 0], [5, 0, 4, 6]], // line 4 is identical to line 4 of source except col 5 was removed eg 01234567890 -> 012346789
+        [[0, 0, 5, 0], [5], [6, 0, 5, 5]], // line 4 is identical to line 4 of source except a char was added at col 5 eg 01234*56789 -> 0123*456789
       ],
       names: ['name'],
       sources: ['child.js'],
@@ -180,12 +182,36 @@ describe('SourceMapTree', () => {
       expect(trace).toMatchObject({ line: 1, column: 1 });
     });
 
+    test('traces all generated cols on a line back to their source when source had characters removed', () => {
+      let expectedCols = [0, 1, 2, 3, 4, 6, 7, 8, 9]
+      let expectedLine = 4;
+      for (var genCol = 0; genCol < expectedCols.length; genCol++ ) {
+         const trace = source.traceSegment(4, genCol, '');
+         expect(trace).toMatchObject({ line: expectedLine, column: expectedCols[genCol] });
+      }
+    });
+
+    test('traces all generated cols on a line back to their source when source had characters added', () => {
+      let expectedCols = [0, 1, 2, 3, 4, null, 5, 6, 7, 8, 9]
+      let expectedLine = 5;
+      for (var genCol = 0; genCol < expectedCols.length; genCol++ ) {
+         const trace = source.traceSegment(5, genCol, '');
+         if (expectedCols[genCol] == null) {
+           expect(trace).toBeNull()
+         } else {
+           expect(trace).toMatchObject({ line: expectedLine, column: expectedCols[genCol] });
+         }
+      }
+    });
+
+
     test('returns null if line is longer than mapping lines', () => {
       const trace = source.traceSegment(10, 0, '');
       expect(trace).toBe(null);
     });
 
     test('returns null if no matching segment column', () => {
+      //line 1 col 0 of generated doesn't exist in the original source
       const trace = source.traceSegment(1, 0, '');
       expect(trace).toBe(null);
     });

--- a/test/unit/source-map-tree.ts
+++ b/test/unit/source-map-tree.ts
@@ -168,7 +168,10 @@ describe('SourceMapTree', () => {
         [[1, 0, 0, 0]], // line 1 - maps to line 0 col 0
         [[0]], // line 2 has 1 length segment
         [[0, 0, 0, 0, 0]], // line 3 has a name
-        [[0, 0, 4, 0], [5, 0, 4, 6]], // line 4 is identical to line 4 of source except col 5 was removed eg 01234567890 -> 012346789
+        [
+          [0, 0, 4, 0],
+          [5, 0, 4, 6],
+        ], // line 4 is identical to line 4 of source except col 5 was removed eg 01234567890 -> 012346789
         [[0, 0, 5, 0], [5], [6, 0, 5, 5]], // line 4 is identical to line 4 of source except a char was added at col 5 eg 01234*56789 -> 0123*456789
       ],
       names: ['name'],
@@ -183,27 +186,26 @@ describe('SourceMapTree', () => {
     });
 
     test('traces all generated cols on a line back to their source when source had characters removed', () => {
-      let expectedCols = [0, 1, 2, 3, 4, 6, 7, 8, 9]
+      let expectedCols = [0, 1, 2, 3, 4, 6, 7, 8, 9];
       let expectedLine = 4;
-      for (var genCol = 0; genCol < expectedCols.length; genCol++ ) {
-         const trace = source.traceSegment(4, genCol, '');
-         expect(trace).toMatchObject({ line: expectedLine, column: expectedCols[genCol] });
+      for (var genCol = 0; genCol < expectedCols.length; genCol++) {
+        const trace = source.traceSegment(4, genCol, '');
+        expect(trace).toMatchObject({ line: expectedLine, column: expectedCols[genCol] });
       }
     });
 
     test('traces all generated cols on a line back to their source when source had characters added', () => {
-      let expectedCols = [0, 1, 2, 3, 4, null, 5, 6, 7, 8, 9]
+      let expectedCols = [0, 1, 2, 3, 4, null, 5, 6, 7, 8, 9];
       let expectedLine = 5;
-      for (var genCol = 0; genCol < expectedCols.length; genCol++ ) {
-         const trace = source.traceSegment(5, genCol, '');
-         if (expectedCols[genCol] == null) {
-           expect(trace).toBeNull()
-         } else {
-           expect(trace).toMatchObject({ line: expectedLine, column: expectedCols[genCol] });
-         }
+      for (var genCol = 0; genCol < expectedCols.length; genCol++) {
+        const trace = source.traceSegment(5, genCol, '');
+        if (expectedCols[genCol] == null) {
+          expect(trace).toBeNull();
+        } else {
+          expect(trace).toMatchObject({ line: expectedLine, column: expectedCols[genCol] });
+        }
       }
     });
-
 
     test('returns null if line is longer than mapping lines', () => {
       const trace = source.traceSegment(10, 0, '');

--- a/test/unit/source-map-tree.ts
+++ b/test/unit/source-map-tree.ts
@@ -187,22 +187,20 @@ describe('SourceMapTree', () => {
 
     test('traces all generated cols on a line back to their source when source had characters removed', () => {
       let expectedCols = [0, 0, 0, 0, 0, 6, 6, 6, 6];
-      let expectedLine = 4;
       for (var genCol = 0; genCol < expectedCols.length; genCol++) {
         const trace = source.traceSegment(4, genCol, '');
-        expect(trace).toMatchObject({ line: expectedLine, column: expectedCols[genCol] });
+        expect(trace).toMatchObject({ line: 4, column: expectedCols[genCol] });
       }
     });
 
     test('traces all generated cols on a line back to their source when source had characters added', () => {
       let expectedCols = [0, 0, 0, 0, 0, null, 5, 5, 5, 5, 5];
-      let expectedLine = 5;
       for (var genCol = 0; genCol < expectedCols.length; genCol++) {
         const trace = source.traceSegment(5, genCol, '');
         if (expectedCols[genCol] == null) {
           expect(trace).toBeNull();
         } else {
-          expect(trace).toMatchObject({ line: expectedLine, column: expectedCols[genCol] });
+          expect(trace).toMatchObject({ line: 5, column: expectedCols[genCol] });
         }
       }
     });

--- a/test/unit/source-map-tree.ts
+++ b/test/unit/source-map-tree.ts
@@ -186,7 +186,7 @@ describe('SourceMapTree', () => {
     });
 
     test('traces all generated cols on a line back to their source when source had characters removed', () => {
-      let expectedCols = [0, 1, 2, 3, 4, 6, 7, 8, 9];
+      let expectedCols = [0, 0, 0, 0, 0, 6, 6, 6, 6];
       let expectedLine = 4;
       for (var genCol = 0; genCol < expectedCols.length; genCol++) {
         const trace = source.traceSegment(4, genCol, '');
@@ -195,7 +195,7 @@ describe('SourceMapTree', () => {
     });
 
     test('traces all generated cols on a line back to their source when source had characters added', () => {
-      let expectedCols = [0, 1, 2, 3, 4, null, 5, 6, 7, 8, 9];
+      let expectedCols = [0, 0, 0, 0, 0, null, 5, 5, 5, 5, 5];
       let expectedLine = 5;
       for (var genCol = 0; genCol < expectedCols.length; genCol++) {
         const trace = source.traceSegment(5, genCol, '');


### PR DESCRIPTION
When trying to find an original source location for a column that doesn't line up with a segment's generated column, source tracing was returning. This PR changes the behaviour so that the lookup will use the offset between the searched for location and the segment start and apply that to the original source column.

I hit this problem when combining a sourcemap with a sourcemap that had simple line passthrough 
```js
[
[[0, 0, 0, 0]],
[[0, 0, 1, 0]]
]
```
with a more complicated transform. The behaviour implemented should give the same results as    
```js
new SourceMapConsumer(map2).originalPositionFor(new SourceMapConsumer(map1).originalPositionFor(generated))
```