### PR TITLE
add dep tslib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7219,9 +7219,9 @@
       }
     },
     "tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+      "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
       "dev": true
     },
     "tslint": {
@@ -7249,6 +7249,12 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
           "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+          "dev": true
+        },
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
           "dev": true
         }
       }
@@ -7303,6 +7309,14 @@
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
+        }
       }
     },
     "tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "rollup-plugin-sourcemaps": "0.6.2",
     "source-map": "0.6.1",
     "ts-jest": "26.1.0",
-    "tslib": "1.13.0",
+    "tslib": "2.0.1",
     "tslint": "6.1.2",
     "tslint-config-prettier": "1.18.0",
     "tslint-config-standard": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "rollup-plugin-sourcemaps": "0.6.2",
     "source-map": "0.6.1",
     "ts-jest": "26.1.0",
-    "tslib": "^2.0.1",
+    "tslib": "1.13.0",
     "tslint": "6.1.2",
     "tslint-config-prettier": "1.18.0",
     "tslint-config-standard": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "rollup-plugin-sourcemaps": "0.6.2",
     "source-map": "0.6.1",
     "ts-jest": "26.1.0",
+    "tslib": "^2.0.1",
     "tslint": "6.1.2",
     "tslint-config-prettier": "1.18.0",
     "tslint-config-standard": "9.0.0",


### PR DESCRIPTION
tslib is required for 'npm run build'

> \> rollup -c rollup.config.js
>
> src/remapping.ts → dist...
> [!] (plugin typescript) Error: @rollup/plugin-typescript TS2354: This syntax requires an imported helper but module 'tslib' cannot be found.

currently, tslib is only in package-lock.json but not in package.json
