### PR TITLE
add option decodeMappings to remapping

### DIFF
--- a/src/build-source-map-tree.ts
+++ b/src/build-source-map-tree.ts
@@ -19,7 +19,7 @@ import OriginalSource from './original-source';
 import resolve from './resolve';
 import SourceMapTree from './source-map-tree';
 import stripFilename from './strip-filename';
-import { SourceMapInput, SourceMapLoader } from './types';
+import { DecodedSourceMap, SourceMapInput, SourceMapLoader } from './types';
 
 function asArray<T>(value: T | T[]): T[] {
   if (Array.isArray(value)) return value;
@@ -43,7 +43,12 @@ export default function buildSourceMapTree(
   relativeRoot?: string,
   segmentsAreSorted?: boolean
 ): SourceMapTree {
-  const maps = asArray(input).map((map: SourceMapInput): DecodedSourceMap => decodeSourceMap(map, segmentsAreSorted)) as DecodedSourceMap[];
+  const maps = asArray(input).map(
+    (map: SourceMapInput): DecodedSourceMap => {
+      return decodeSourceMap(map, segmentsAreSorted);
+    }
+  );
+  // as DecodedSourceMap[];
   const map = maps.pop()!;
 
   for (let i = 0; i < maps.length; i++) {
@@ -79,7 +84,7 @@ export default function buildSourceMapTree(
 
     // Else, it's a real sourcemap, and we need to recurse into it to load its
     // source files.
-    return buildSourceMapTree(decodeSourceMap(sourceMap), loader, uri);
+    return buildSourceMapTree(decodeSourceMap(sourceMap, segmentsAreSorted), loader, uri);
   });
 
   let tree = new SourceMapTree(map, children);

--- a/src/build-source-map-tree.ts
+++ b/src/build-source-map-tree.ts
@@ -40,9 +40,10 @@ function asArray<T>(value: T | T[]): T[] {
 export default function buildSourceMapTree(
   input: SourceMapInput | SourceMapInput[],
   loader: SourceMapLoader,
-  relativeRoot?: string
+  relativeRoot?: string,
+  segmentsAreSorted?: boolean
 ): SourceMapTree {
-  const maps = asArray(input).map(decodeSourceMap);
+  const maps = asArray(input).map((map: SourceMapInput): DecodedSourceMap => decodeSourceMap(map, segmentsAreSorted)) as DecodedSourceMap[];
   const map = maps.pop()!;
 
   for (let i = 0; i < maps.length; i++) {

--- a/src/decode-source-map.ts
+++ b/src/decode-source-map.ts
@@ -24,7 +24,7 @@ import { DecodedSourceMap, RawSourceMap, SourceMapInput, SourceMapSegment } from
  * Valid input maps include a `DecodedSourceMap`, a `RawSourceMap`, or JSON
  * representations of either type.
  */
-export default function decodeSourceMap(map: SourceMapInput): DecodedSourceMap {
+export default function decodeSourceMap(map: SourceMapInput, segmentsAreSorted?: boolean): DecodedSourceMap {
   if (typeof map === 'string') {
     map = JSON.parse(map) as DecodedSourceMap | RawSourceMap;
   }
@@ -32,15 +32,17 @@ export default function decodeSourceMap(map: SourceMapInput): DecodedSourceMap {
   let { mappings } = map;
   if (typeof mappings === 'string') {
     mappings = decode(mappings);
-  } else {
+  } else if (!segmentsAreSorted) {
     // Clone the Line so that we can sort it. We don't want to mutate an array
     // that we don't own directly.
     mappings = mappings.map(cloneSegmentLine);
   }
-  // Sort each Line's segments. There's no guarantee that segments are sorted for us,
-  // and even Chrome's implementation sorts:
-  // https://cs.chromium.org/chromium/src/third_party/devtools-frontend/src/front_end/sdk/SourceMap.js?l=507-508&rcl=109232bcf479c8f4ef8ead3cf56c49eb25f8c2f0
-  mappings.forEach(sortSegments);
+  if (!segmentsAreSorted) {
+    // Sort each Line's segments. There's no guarantee that segments are sorted for us,
+    // and even Chrome's implementation sorts:
+    // https://cs.chromium.org/chromium/src/third_party/devtools-frontend/src/front_end/sdk/SourceMap.js?l=507-508&rcl=109232bcf479c8f4ef8ead3cf56c49eb25f8c2f0
+    mappings.forEach(sortSegments);
+  }
 
   return defaults({ mappings }, map);
 }

--- a/src/decode-source-map.ts
+++ b/src/decode-source-map.ts
@@ -24,7 +24,10 @@ import { DecodedSourceMap, RawSourceMap, SourceMapInput, SourceMapSegment } from
  * Valid input maps include a `DecodedSourceMap`, a `RawSourceMap`, or JSON
  * representations of either type.
  */
-export default function decodeSourceMap(map: SourceMapInput, segmentsAreSorted?: boolean): DecodedSourceMap {
+export default function decodeSourceMap(
+  map: SourceMapInput,
+  segmentsAreSorted?: boolean
+): DecodedSourceMap {
   if (typeof map === 'string') {
     map = JSON.parse(map) as DecodedSourceMap | RawSourceMap;
   }

--- a/src/remapping.ts
+++ b/src/remapping.ts
@@ -36,9 +36,10 @@ export default function remapping(
   input: SourceMapInput | SourceMapInput[],
   loader: SourceMapLoader,
   excludeContent?: boolean,
-  decodeMappings?: boolean
+  decodeMappings?: boolean,
+  segmentsAreSorted?: boolean
 ): SourceMap | DecodedSourceMap {
-  const graph = buildSourceMapTree(input, loader);
+  const graph = buildSourceMapTree(input, loader, '', !!segmentsAreSorted);
   return decodeMappings
     ? graph.traceMappings()
     : new SourceMap(graph.traceMappings(), !!excludeContent);

--- a/src/remapping.ts
+++ b/src/remapping.ts
@@ -16,7 +16,7 @@
 
 import buildSourceMapTree from './build-source-map-tree';
 import SourceMap from './source-map';
-import { SourceMapInput, SourceMapLoader } from './types';
+import { DecodedSourceMap, SourceMapInput, SourceMapLoader } from './types';
 
 /**
  * Traces through all the mappings in the root sourcemap, through the sources
@@ -27,14 +27,19 @@ import { SourceMapInput, SourceMapLoader } from './types';
  * it returns a falsey value, that source file is treated as an original,
  * unmodified source file.
  *
- * Pass `excludeContent` content to exclude any self-containing source file
- * content from the output sourcemap.
+ * Pass `excludeContent` to exclude any self-containing source file content
+ * from the output sourcemap.
+ *
+ * Pass `decodeMappings` to get a sourcemap with decoded mappings.
  */
 export default function remapping(
   input: SourceMapInput | SourceMapInput[],
   loader: SourceMapLoader,
-  excludeContent?: boolean
-): SourceMap {
+  excludeContent?: boolean,
+  decodeMappings?: boolean
+): SourceMap | DecodedSourceMap {
   const graph = buildSourceMapTree(input, loader);
-  return new SourceMap(graph.traceMappings(), !!excludeContent);
+  return decodeMappings
+    ? graph.traceMappings()
+    : new SourceMap(graph.traceMappings(), !!excludeContent);
 }

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -15,25 +15,25 @@
  */
 
 import { encode } from 'sourcemap-codec';
-import { DecodedSourceMap, RawSourceMap } from './types';
+import { DecodedSourceMap, RawOrDecodedSourceMap, SourceMapSegment } from './types';
 
 /**
  * A SourceMap v3 compatible sourcemap, which only includes fields that were
  * provided to it.
  */
-export default class SourceMap implements RawSourceMap {
+export default class SourceMap implements RawOrDecodedSourceMap {
   file?: string | null;
-  mappings: string;
+  mappings: string | SourceMapSegment[][];
   sourceRoot?: string;
   names: string[];
   sources: (string | null)[];
   sourcesContent?: (string | null)[];
   version: 3;
 
-  constructor(map: DecodedSourceMap, excludeContent: boolean) {
+  constructor(map: DecodedSourceMap, excludeContent: boolean, skipEncodeMappings: boolean) {
     this.version = 3; // SourceMap spec says this should be first.
     if ('file' in map) this.file = map.file;
-    this.mappings = encode(map.mappings);
+    this.mappings = skipEncodeMappings ? map.mappings : encode(map.mappings);
     this.names = map.names;
 
     // TODO: We first need to make all source URIs relative to the sourceRoot

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,10 @@ export interface DecodedSourceMap extends SourceMapV3 {
   mappings: SourceMapSegment[][];
 }
 
+export interface RawOrDecodedSourceMap extends SourceMapV3 {
+  mappings: string | SourceMapSegment[][];
+}
+
 export interface SourceMapSegmentObject {
   column: number;
   line: number;

--- a/test/unit/remapping.ts
+++ b/test/unit/remapping.ts
@@ -15,7 +15,7 @@
  */
 
 import remapping from '../../src/remapping';
-import { RawSourceMap } from '../../src/types';
+import { DecodedSourceMap, RawSourceMap } from '../../src/types';
 
 describe('remapping', () => {
   const rawMap: RawSourceMap = {
@@ -42,6 +42,16 @@ describe('remapping', () => {
     // 0th column of 1st line of output file translates into the 1st source
     // file, line 3, column 2, using first name
     mappings: 'AAEEA',
+    names: ['add'],
+    // TODO: support sourceRoot
+    // sourceRoot: '',
+    sources: ['helloworld.js'],
+    sourcesContent: ['\n\n  1 + 1;'],
+    version: 3,
+  };
+  const decodedMap: DecodedSourceMap = {
+    file: 'transpiled.min.js',
+    mappings: [[[0, 0, 2, 2, 0]]],
     names: ['add'],
     // TODO: support sourceRoot
     // sourceRoot: '',
@@ -154,5 +164,20 @@ describe('remapping', () => {
     );
 
     expect(map).not.toHaveProperty('sourcesContent');
+  });
+
+  test('returns decoded mappings if `decodeMappings` is set', () => {
+    const map = remapping(
+      rawMap,
+      (name: string) => {
+        if (name === 'transpiled.js') {
+          return transpiledMap;
+        }
+      },
+      false,
+      true
+    );
+
+    expect(map).toEqual(decodedMap);
   });
 });

--- a/test/unit/source-map.ts
+++ b/test/unit/source-map.ts
@@ -26,7 +26,7 @@ describe('SourceMap', () => {
   };
 
   test('it is a compliant, v3 sourcemap', () => {
-    const map = new SourceMap(decoded, false);
+    const map = new SourceMap(decoded, false, false);
     expect(map).toHaveProperty('mappings', 'AAAA');
     expect(map).toHaveProperty('names', decoded.names);
     expect(map).toHaveProperty('sources', decoded.sources);
@@ -34,7 +34,7 @@ describe('SourceMap', () => {
   });
 
   test('it does not include properties missing from input', () => {
-    const map = new SourceMap(decoded, false);
+    const map = new SourceMap(decoded, false, false);
     expect(map).not.toHaveProperty('file');
     expect(map).not.toHaveProperty('sourceRoot');
     expect(map).not.toHaveProperty('sourcesContent');
@@ -42,32 +42,38 @@ describe('SourceMap', () => {
 
   test('it can include a file', () => {
     const file = 'foobar.js';
-    const map = new SourceMap({ ...decoded, file }, false);
+    const map = new SourceMap({ ...decoded, file }, false, false);
     expect(map).toHaveProperty('file', file);
   });
 
   // TODO: support sourceRoot
   test.skip('it can include a sourceRoot', () => {
     const sourceRoot = 'https://foo.com/';
-    const map = new SourceMap({ ...decoded, sourceRoot }, false);
+    const map = new SourceMap({ ...decoded, sourceRoot }, false, false);
     expect(map).toHaveProperty('sourceRoot', sourceRoot);
   });
 
   test('it can include a sourcesContent', () => {
     const sourcesContent = ['1 + 1'];
-    const map = new SourceMap({ ...decoded, sourcesContent }, false);
+    const map = new SourceMap({ ...decoded, sourcesContent }, false, false);
     expect(map).toHaveProperty('sourcesContent', sourcesContent);
   });
 
   test('sourcesContent can be manually excluded', () => {
     const sourcesContent = ['1 + 1'];
-    const map = new SourceMap({ ...decoded, sourcesContent }, true);
+    const map = new SourceMap({ ...decoded, sourcesContent }, true, false);
     expect(map).not.toHaveProperty('sourcesContent');
+  });
+
+  test('can return decoded mappings', () => {
+    const sourcesContent = ['1 + 1'];
+    const map = new SourceMap({ ...decoded, sourcesContent }, false, true);
+    expect(map).toHaveProperty('mappings', [[[0, 0, 0, 0]]]);
   });
 
   describe('toString()', () => {
     test('returns the sourcemap in JSON', () => {
-      const map = new SourceMap(decoded, false);
+      const map = new SourceMap(decoded, false, false);
       expect(JSON.parse(map.toString())).toEqual(map);
     });
   });


### PR DESCRIPTION
option `decodeMappings`: skip unnecessary encode+decode steps

option `segmentsAreSorted`: skip unnecessary sorting of segments
todo: is it sufficient to sort segments only once after all sourcemaps are combined?
probably not, otherwise column-ranges are broken, so input segments must always be sorted

related to issue #85 