### PR TITLE
fix npm run --no-cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:lint:ts": "tslint  --project tsconfig.json -t codeFrame '{src,test}/**/*.ts'",
     "test:lint:prettier": "prettier --check '{src,test}/**/*.ts'",
     "test:lint": "run-s -n test:lint:*",
-    "test:prod": "run-s -n test:lint 'test --no-cache'",
+    "test:prod": "run-s -n test:lint 'test --prefer-online'",
     "preversion": "run-s test:prod build",
     "prepublishOnly": "npm run preversion"
   },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:lint:ts": "tslint  --project tsconfig.json -t codeFrame '{src,test}/**/*.ts'",
     "test:lint:prettier": "prettier --check '{src,test}/**/*.ts'",
     "test:lint": "run-s -n test:lint:*",
-    "test:prod": "run-s -n test:lint 'test --prefer-online'",
+    "test:prod": "run-s -n test:lint 'test -- --no-cache'",
     "preversion": "run-s test:prod build",
     "prepublishOnly": "npm run preversion"
   },


### PR DESCRIPTION
option `--no-cache` has no effect, should be `--prefer-online`
https://github.com/npm/cli/issues/1159

option is passed to `npm run`, not to `jest`, see [here](https://travis-ci.org/github/ampproject/remapping/jobs/730917786#L242)

probably makes only sense with `npm install`?

jest cache is cleared with `jest --clearCache`, if that was the intention



```
$ npm help 7 config

prefer-online
• Default: false

• Type: Boolean

If  true,  staleness  checks for cached data will be forced, making the
CLI look for updates immediately even for fresh package data.
```