### PR TITLE
Memoize last binary search index

### DIFF
--- a/src/binary-search.ts
+++ b/src/binary-search.ts
@@ -42,11 +42,11 @@
 export default function binarySearch<T, S>(
   haystack: ArrayLike<T>,
   needle: S,
-  comparator: (item: T, needle: S) => number
+  comparator: (item: T, needle: S) => number,
+  low: number,
+  high: number
 ): number {
-  let low = 0;
-  let high = haystack.length - 1;
-
+  low = Math.max(low, 0);
   while (low <= high) {
     const mid = low + ((high - low) >> 1);
     const cmp = comparator(haystack[mid], needle);

--- a/test/unit/binary-search.ts
+++ b/test/unit/binary-search.ts
@@ -27,7 +27,7 @@ describe('binary search', () => {
       array.push(i * 2);
       for (let j = 0; j < array.length; j++) {
         const needle = j * 2;
-        const index = binarySearch(array, needle, comparator);
+        const index = binarySearch(array, needle, comparator, 0, array.length - 1);
 
         expect(index).toEqual(j);
 
@@ -43,7 +43,7 @@ describe('binary search', () => {
       array.push(i * 2);
       for (let j = 0; j < array.length; j++) {
         const needle = j * 2 - 1;
-        const index = binarySearch(array, needle, comparator);
+        const index = binarySearch(array, needle, comparator, 0, array.length - 1);
         const negated = ~index;
 
         expect(index).toBeLessThan(0);
@@ -65,7 +65,7 @@ describe('binary search', () => {
 
     for (let i = 0; i < 9; i++) {
       array.push(i * 2);
-      const index = binarySearch(array, needle, comparator);
+      const index = binarySearch(array, needle, comparator, 0, array.length - 1);
       const negated = ~index;
 
       expect(index).toBeLessThan(0);
@@ -80,7 +80,7 @@ describe('binary search', () => {
 
     for (let i = 0; i < 9; i++) {
       array.push(i * 2);
-      const index = binarySearch(array, needle, comparator);
+      const index = binarySearch(array, needle, comparator, 0, array.length - 1);
       const negated = ~index;
 
       expect(index).toBeLessThan(0);
@@ -92,13 +92,13 @@ describe('binary search', () => {
   test('empty array', () => {
     const array: number[] = [];
     const needle = 1;
-    const index = binarySearch(array, needle, comparator);
+    const index = binarySearch(array, needle, comparator, 0, array.length - 1);
 
     expect(index).toBeLessThan(0);
     expect(~index).toEqual(0);
   });
 
-  test('multilpe items in array returns valid matches', () => {
+  test('multiple items in array returns valid matches', () => {
     const array: number[] = [1];
     const needle = 1;
     const expectedIndex = 0;
@@ -107,10 +107,183 @@ describe('binary search', () => {
     for (; attempts < 10; attempts++) {
       array.push(needle);
 
-      const index = binarySearch(array, needle, comparator);
+      const index = binarySearch(array, needle, comparator, 0, array.length - 1);
       if (index !== expectedIndex) break;
     }
 
     expect(attempts).toBeLessThan(10);
+  });
+
+  describe('low', () => {
+    test('low equals needle index', () => {
+      const array: number[] = [];
+      for (let i = 0; i < 9; i++) {
+        array.push(i * 2);
+        for (let j = 0; j < array.length; j++) {
+          const needle = j * 2;
+          const index = binarySearch(array, needle, comparator, j, array.length - 1);
+
+          expect(index).toEqual(j);
+
+          expect(array[index]).toEqual(needle);
+        }
+      }
+    });
+
+    test('low higher than needle index', () => {
+      const array: number[] = [];
+      for (let i = 0; i < 9; i++) {
+        array.push(i * 2);
+        for (let j = 0; j < array.length; j++) {
+          const needle = j * 2;
+          const index = binarySearch(array, needle, comparator, j + 1, array.length - 1);
+          const negated = ~index;
+
+          expect(index).toBeLessThan(0);
+          expect(negated).toBe(j + 1);
+        }
+      }
+    });
+
+    test('low lower than needle index', () => {
+      const array: number[] = [];
+      for (let i = 0; i < 9; i++) {
+        array.push(i * 2);
+        for (let j = 0; j < array.length; j++) {
+          const needle = j * 2;
+          const index = binarySearch(array, needle, comparator, j - 1, array.length - 1);
+
+          expect(index).toBe(j);
+        }
+      }
+    });
+  });
+
+  describe('low', () => {
+    test('low equals needle index', () => {
+      const array: number[] = [];
+      for (let i = 0; i < 9; i++) {
+        array.push(i * 2);
+        for (let j = 0; j < array.length; j++) {
+          const needle = j * 2;
+          const index = binarySearch(array, needle, comparator, j, array.length - 1);
+
+          expect(index).toEqual(j);
+
+          expect(array[index]).toEqual(needle);
+        }
+      }
+    });
+
+    test('low higher than needle index', () => {
+      const array: number[] = [];
+      for (let i = 0; i < 9; i++) {
+        array.push(i * 2);
+        for (let j = 0; j < array.length; j++) {
+          const needle = j * 2;
+          const index = binarySearch(array, needle, comparator, j + 1, array.length - 1);
+          const negated = ~index;
+
+          expect(index).toBeLessThan(0);
+          expect(negated).toBe(j + 1);
+        }
+      }
+    });
+
+    test('low lower than needle index', () => {
+      const array: number[] = [];
+      for (let i = 0; i < 9; i++) {
+        array.push(i * 2);
+        for (let j = 0; j < array.length; j++) {
+          const needle = j * 2;
+          const index = binarySearch(array, needle, comparator, j - 1, array.length - 1);
+
+          expect(index).toBe(j);
+        }
+      }
+    });
+
+    test('low equals -1', () => {
+      const array: number[] = [];
+      Object.defineProperty(array, '-1', {
+        get() {
+          throw new Error('access to negative index');
+        },
+      });
+
+      for (let i = 0; i < 9; i++) {
+        array.push(i * 2);
+        for (let j = 0; j < array.length; j++) {
+          const needle = j * 2;
+          const index = binarySearch(array, needle, comparator, -1, array.length - 1);
+
+          expect(index).toBe(j);
+        }
+      }
+    });
+  });
+
+  describe('high', () => {
+    test('high equals needle index', () => {
+      const array: number[] = [];
+      for (let i = 0; i < 9; i++) {
+        array.push(i * 2);
+        for (let j = 0; j < array.length; j++) {
+          const needle = j * 2;
+          const index = binarySearch(array, needle, comparator, 0, j);
+
+          expect(index).toEqual(j);
+
+          expect(array[index]).toEqual(needle);
+        }
+      }
+    });
+
+    test('high higher than needle index', () => {
+      const array: number[] = [];
+      for (let i = 0; i < 9; i++) {
+        array.push(i * 2);
+        for (let j = 0; j < array.length; j++) {
+          const needle = j * 2;
+          const index = binarySearch(array, needle, comparator, 0, j + 1);
+
+          expect(index).toBe(j);
+        }
+      }
+    });
+
+    test('high lower than needle index', () => {
+      const array: number[] = [];
+      for (let i = 0; i < 9; i++) {
+        array.push(i * 2);
+        for (let j = 0; j < array.length; j++) {
+          const needle = j * 2;
+          const index = binarySearch(array, needle, comparator, 0, j - 1);
+          const negated = ~index;
+
+          expect(index).toBeLessThan(0);
+          expect(negated).toBe(j);
+        }
+      }
+    });
+
+    test('high equals -1', () => {
+      const array: number[] = [];
+      Object.defineProperty(array, '-1', {
+        get() {
+          throw new Error('access to negative index');
+        },
+      });
+
+      for (let i = 0; i < 9; i++) {
+        array.push(i * 2);
+        for (let j = 0; j < array.length; j++) {
+          const needle = j * 2;
+          const index = binarySearch(array, needle, comparator, 0, -1);
+
+          expect(index).toBe(-1);
+        }
+      }
+    });
   });
 });

--- a/test/unit/source-map-tree.ts
+++ b/test/unit/source-map-tree.ts
@@ -165,7 +165,7 @@ describe('SourceMapTree', () => {
           [2, 0, 0, 0],
           [4, 0, 1, 1],
         ], // line 0
-        [[1, 0, 0, 0]], // line 1 - maps to line 0 col 0
+        [[2, 0, 0, 0]], // line 1 - maps to line 0 col 0
         [[0]], // line 2 has 1 length segment
         [[0, 0, 0, 0, 0]], // line 3 has a name
         [
@@ -198,7 +198,7 @@ describe('SourceMapTree', () => {
       for (let genCol = 0; genCol < expectedCols.length; genCol++) {
         const trace = source.traceSegment(5, genCol, '');
         if (expectedCols[genCol] == null) {
-          expect(trace).toBeNull();
+          expect(trace).toBe(null);
         } else {
           expect(trace).toMatchObject({ line: 5, column: expectedCols[genCol] });
         }
@@ -229,6 +229,54 @@ describe('SourceMapTree', () => {
     test('overrides name if segment is 5-length', () => {
       const trace = source.traceSegment(3, 0, 'foo');
       expect(trace).toMatchObject({ name: 'name' });
+    });
+
+    describe('tracing same line multiple times', () => {
+      describe('later column', () => {
+        test('returns matching segment after match', () => {
+          expect(source.traceSegment(0, 1, '')).not.toBe(null);
+          const trace = source.traceSegment(0, 4, '');
+          expect(trace).toMatchObject({ line: 1, column: 1 });
+        });
+
+        test('returns matching segment after null match', () => {
+          expect(source.traceSegment(1, 0, '')).toBe(null);
+          const trace = source.traceSegment(1, 2, '');
+          expect(trace).toMatchObject({ line: 0, column: 0 });
+        });
+
+        test('returns null segment segment after null match', () => {
+          expect(source.traceSegment(1, 0, '')).toBe(null);
+          const trace = source.traceSegment(1, 1, '');
+          expect(trace).toBe(null);
+        });
+
+        test('returns matching segment after almost match', () => {
+          expect(source.traceSegment(4, 2, '')).not.toBe(null);
+          const trace = source.traceSegment(4, 5, '');
+          expect(trace).toMatchObject({ line: 4, column: 6 });
+        });
+      });
+
+      describe('earlier column', () => {
+        test('returns matching segment after match', () => {
+          expect(source.traceSegment(0, 4, '')).not.toBe(null);
+          const trace = source.traceSegment(0, 1, '');
+          expect(trace).toMatchObject({ line: 0, column: 0 });
+        });
+
+        test('returns null segment segment after null match', () => {
+          expect(source.traceSegment(1, 1, '')).toBe(null);
+          const trace = source.traceSegment(1, 0, '');
+          expect(trace).toBe(null);
+        });
+
+        test('returns matching segment after almost match', () => {
+          expect(source.traceSegment(4, 2, '')).not.toBe(null);
+          const trace = source.traceSegment(4, 0, '');
+          expect(trace).toMatchObject({ line: 4, column: 0 });
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
This is a perf optimization where we remember the last matched index from a binary search on the
same array, so we can avoid rescanning segments we know won't match (they're either too small and
before the last match index, or too large and after the last match index).