### PR TITLE
Truncate mappings to the last line with a valid segment

### DIFF
--- a/src/source-map-tree.ts
+++ b/src/source-map-tree.ts
@@ -54,6 +54,7 @@ export default class SourceMapTree {
     const sourcesContent: (string | null)[] = [];
     const { mappings: rootMappings, names: rootNames } = this.map;
 
+    let lastLineWithSegment = -1;
     for (let i = 0; i < rootMappings.length; i++) {
       const segments = rootMappings[i];
       const tracedSegments: SourceMapSegment[] = [];
@@ -105,9 +106,13 @@ export default class SourceMapTree {
           lastTraced = [segment[0], sourceIndex, line, column];
         }
         tracedSegments.push(lastTraced);
+        lastLineWithSegment = i;
       }
 
       mappings.push(tracedSegments);
+    }
+    if (mappings.length > lastLineWithSegment + 1) {
+      mappings.length = lastLineWithSegment + 1;
     }
 
     // TODO: Make all sources relative to the sourceRoot.

--- a/test/unit/source-map-tree.ts
+++ b/test/unit/source-map-tree.ts
@@ -54,7 +54,7 @@ describe('SourceMapTree', () => {
 
       const source = new SourceMapTree(map, [child]);
       const traced = source.traceMappings();
-      expect(traced.mappings).toEqual([[]]);
+      expect(traced.mappings).toEqual([]);
     });
 
     test('skips segment if trace returns null', () => {
@@ -68,7 +68,7 @@ describe('SourceMapTree', () => {
 
       const source = new SourceMapTree(map, [child]);
       const traced = source.traceMappings();
-      expect(traced.mappings).toEqual([[]]);
+      expect(traced.mappings).toEqual([]);
     });
 
     test('traces name if segment is 5-length', () => {
@@ -152,6 +152,34 @@ describe('SourceMapTree', () => {
       const traced = source.traceMappings();
       expect(traced).toMatchObject({
         sources: ['child.js'],
+      });
+    });
+
+    test('truncates mappings to the last line with segment', () => {
+      const map: DecodedSourceMap = {
+        ...baseMap,
+        mappings: [[[0, 0, 0, 0]], [], []],
+        sourceRoot,
+      };
+
+      const source = new SourceMapTree(map, [child]);
+      const traced = source.traceMappings();
+      expect(traced).toMatchObject({
+        mappings: [[[0, 0, 0, 0]]],
+      });
+    });
+
+    test('truncates empty mappings', () => {
+      const map: DecodedSourceMap = {
+        ...baseMap,
+        mappings: [[], [], []],
+        sourceRoot,
+      };
+
+      const source = new SourceMapTree(map, [child]);
+      const traced = source.traceMappings();
+      expect(traced).toMatchObject({
+        mappings: [],
       });
     });
 


### PR DESCRIPTION
Re: #116, which has an sourcemap without any segments. There's no point in keeping trailing lines
without any segments, and truncating better matches the output from `source-map`.